### PR TITLE
Mudar para call4paperz

### DIFF
--- a/_posts/2016-09-19-decimo-nono-encontro.md
+++ b/_posts/2016-09-19-decimo-nono-encontro.md
@@ -9,7 +9,7 @@ Finalmente, o primeiro encontro de 2016 chegou! É isso aí, infelizmente estive
 
 O encontro ocorrerá no dia **4 de outubro**, na _Livraria Leitura_ do shopping Rio Mar, às 19:00.
 
-Ainda dá tempo de mandar a sua proposta de palestra pelo [Speaker Fight](http://speakerfight.com/events/19-encontro-do-guru-ce/)
+Ainda dá tempo de mandar a sua proposta de palestra pelo [call4paperz](http://call4paperz.com/events/19-encontro-do-guru-ce)
 
 Contamos com a sua participação, inscreva-se [aqui](https://www.eventick.com.br/19o-encontro-do-guru-ce).
 


### PR DESCRIPTION
Estava falando com o @lucazz e vimos que o SpeakerFight é muito bom. Dessa forma, resolvemos voltar para o velho e bom call4paperz. As palestras já foram recadastradas. Anotamos os votos da anterior.