### PR TITLE
Fix Liquid warnings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
   <footer class="site-footer">
     <a class="subscribe icon-feed" href="{{ site.baseurl }}feed.xml"><span class="tooltip">Subscribe!</span></a>
     <div class="inner">
-      <section class="copyright">All content copyright <a href="{{ site.baseurl }}">{{ site.name }}</a> &copy; {{date format="YYYY"}} &bull; All rights reserved.</section>
+      <section class="copyright">All content copyright <a href="{{ site.baseurl }}">{{ site.name }}</a> &copy; {{ "now" | date: "%Y" }} &bull; All rights reserved.</section>
       <section class="poweredby">Made with Jekyll using <a href="http://github.com/rosario/kasper">Kasper theme</a></section>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ about: 'about.html'
 
     <article class="post">
         <header class="post-header">
-            <span class="post-meta"><time datetime="{{ post.date | date:"%Y-%m-%d" }}">{{ post.date | date_to_string }}</time> {{!tags prefix="on "}}</span>
+            <span class="post-meta"><time datetime="{{ post.date | date:"%Y-%m-%d" }}">{{ post.date | date_to_string }}</time> </span>
             <h2 class="post-title"><a href="{{ post.url }}">{{ post.title }}</a></h2>
 
         </header>


### PR DESCRIPTION
This PR fixes a couple liquid warnings that we were getting, like: 

```
 Jekyll Feed: Generating feed for posts
    Liquid Warning: Liquid syntax error (line 31): Expected end_of_string but found colon in "{{ date: "%Y" }}" in /_layouts/default.html
```
and 
```
Liquid Warning: Liquid syntax error (line 31): Unexpected character ! in "{{!tags prefix="on "}}" in index.html
```
